### PR TITLE
Update Mongoose dependency that included some borked 3.9.x version. Fixes #14

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "express": "~4.9.7",
     "express-handlebars": "~1.1.0",
-    "mongoose": "^3.8.23",
+    "mongoose": "~4.4.1",
     "node-jsx": "~0.12.4",
     "react": "~0.13.3",
     "socket.io": "^1.1.0",


### PR DESCRIPTION
The Mongoose github recommends ~3.8.x or ~4.4.x ...something was broken in 3.9.

This should fix #14
